### PR TITLE
Split endpoint-reorder-or-replace-playlists-tracks for Java

### DIFF
--- a/spotify-web-api-core/src/main/java/de/jsone_studios/spotify/core/EndpointSplitter.java
+++ b/spotify-web-api-core/src/main/java/de/jsone_studios/spotify/core/EndpointSplitter.java
@@ -1,0 +1,137 @@
+package de.jsone_studios.spotify.core;
+
+import de.jsone_studios.spotify.core.model.SpotifyApiDocumentation;
+import de.jsone_studios.spotify.core.model.SpotifyApiEndpoint;
+import de.jsone_studios.spotify.core.model.SpotifyScope;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class EndpointSplitter {
+
+    public static void splitEndpoints(SpotifyApiDocumentation apiDocumentation) throws IllegalArgumentException {
+        splitUsersTopArtistsAndTracksEndpoint(apiDocumentation);
+        splitReorderOrReplacePlaylistsTracksEndpoint(apiDocumentation);
+    }
+
+    public static void splitUsersTopArtistsAndTracksEndpoint(SpotifyApiDocumentation apiDocumentation) throws IllegalArgumentException {
+        var category = apiDocumentation.getCategory("category-personalization")
+                .orElseThrow(() -> new IllegalArgumentException("Can not find category-personalization"));
+
+        var topArtistsAndTracks = category.getEndpoint("endpoint-get-users-top-artists-and-tracks")
+                .orElseThrow(() -> new IllegalArgumentException("Can not find endpoint-get-users-top-artists-and-tracks"));
+
+        var parameters = new ArrayList<>(topArtistsAndTracks.getParameters());
+        parameters.removeIf(p -> "type".equals(p.getName()));
+
+        var responseDescriptionArtists = "On success, the HTTP status code in the response header" +
+                " is `200 OK` and the response body contains a [paging object](https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object)" +
+                " of [Artists](https://developer.spotify.com/documentation/web-api/reference/object-model/#artist-object-full)." +
+                " On error, the header status code is an [error code](https://developer.spotify.com/documentation/web-api/#response-status-codes)" +
+                " and the response body contains an [error object](https://developer.spotify.com/documentation/web-api/#response-schema).";
+
+        var responseDescriptionTracks = "On success, the HTTP status code in the response header" +
+                " is `200 OK` and the response body contains a [paging object](https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object)" +
+                " of [Tracks](https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full)." +
+                " On error, the header status code is an [error code](https://developer.spotify.com/documentation/web-api/#response-status-codes)" +
+                " and the response body contains an [error object](https://developer.spotify.com/documentation/web-api/#response-schema).";
+
+        var topArtists = new SpotifyApiEndpoint(
+                "endpoint-get-users-top-artists",
+                "Get a User's Top Artists",
+                topArtistsAndTracks.getLink(),
+                "Get the current user’s top artists based on calculated affinity.",
+                "GET",
+                "/me/top/artists",
+                parameters,
+                responseDescriptionArtists,
+                topArtistsAndTracks.getScopes(),
+                topArtistsAndTracks.getNotes(),
+                List.of(new SpotifyApiEndpoint.ResponseType("PagingObject[ArtistObject]", 200, null))
+        );
+        var topTracks = new SpotifyApiEndpoint(
+                "endpoint-get-users-top-tracks",
+                "Get a User's Top Tracks",
+                topArtistsAndTracks.getLink(),
+                "Get the current user’s top tracks based on calculated affinity.",
+                "GET",
+                "/me/top/tracks",
+                parameters,
+                responseDescriptionTracks,
+                topArtistsAndTracks.getScopes(),
+                topArtistsAndTracks.getNotes(),
+                List.of(new SpotifyApiEndpoint.ResponseType("PagingObject[TrackObject]", 200, null))
+        );
+
+        category.getEndpoints().remove(topArtistsAndTracks.getId());
+        category.getEndpoints().put(topArtists.getId(), topArtists);
+        category.getEndpoints().put(topTracks.getId(), topTracks);
+
+        topArtistsAndTracks.getScopes().stream()
+                .map(apiDocumentation.getScopes()::getScope)
+                .filter(Optional::isPresent)
+                .forEach(scope -> {
+                    scope.get().getEndpoints().removeIf(e -> topArtistsAndTracks.getId().equals(e.getEndpoint()));
+                    scope.get().getEndpoints().add(new SpotifyScope.EndpointLink(topArtistsAndTracks.getLink(), "web-api", topArtists.getId()));
+                    scope.get().getEndpoints().add(new SpotifyScope.EndpointLink(topArtistsAndTracks.getLink(), "web-api", topTracks.getId()));
+                });
+    }
+
+    public static void splitReorderOrReplacePlaylistsTracksEndpoint(SpotifyApiDocumentation apiDocumentation) {
+        var category = apiDocumentation.getCategory("category-playlists")
+                .orElseThrow(() -> new IllegalArgumentException("Can not find category-playlists"));
+
+        var endpoint = category.getEndpoint("endpoint-reorder-or-replace-playlists-tracks")
+                .orElseThrow(() -> new IllegalArgumentException("Can not find endpoint-reorder-or-replace-playlists-tracks"));
+
+        var reorderParameterNames = List.of("Authorization", "Content-Type", "playlist_id", "range_start", "insert_before", "range_length", "snapshot_id");
+        var replaceParameterNames = List.of("Authorization", "Content-Type", "playlist_id", "uris");
+
+        var reorderResponseDescription = "On a successful **reorder** operation, the response" +
+                " body contains a `snapshot_id` in JSON format and the HTTP status code" +
+                " in the response header is `200` OK. The `snapshot_id` can be used to" +
+                " identify your playlist version in future requests.";
+
+        var replaceResponseDescription = "On a successful **replace** operation, the HTTP status" +
+                " code in the response header is `201` Created.";
+
+        var errorResponseDescription = "On error, the header status code is an [error code](https://developer.spotify.com/documentation/web-api/#response-status-codes)," +
+                " the response body contains an [error object](https://developer.spotify.com/documentation/web-api/#response-schema)," +
+                " and the existing playlist is unmodified. Trying to set an item when you" +
+                " do not have the user's authorization returns error `403` Forbidden.";
+
+        var reorderEndpoint = new SpotifyApiEndpoint(
+                "endpoint-reorder-playlists-tracks",
+                "Reorder items in a playlist",
+                endpoint.getLink(),
+                "Reorder an item or a group of items in a playlist.",
+                endpoint.getHttpMethod(),
+                endpoint.getPath(),
+                endpoint.getParameters().stream().filter(p -> reorderParameterNames.contains(p.getName())).collect(Collectors.toList()),
+                reorderResponseDescription + "\n\n" + errorResponseDescription,
+                endpoint.getScopes(),
+                endpoint.getNotes(),
+                List.of(new SpotifyApiEndpoint.ResponseType("SnapshotIdObject", 200, null))
+        );
+
+        var replaceEndpoint = new SpotifyApiEndpoint(
+                "endpoint-replace-playlists-tracks",
+                "Replace items in a playlist",
+                endpoint.getLink(),
+                "Replace all the items in a playlist, overwriting its existing items. This powerful request can be useful for replacing items, re-ordering existing items, or clearing the playlist.",
+                endpoint.getHttpMethod(),
+                endpoint.getPath(),
+                endpoint.getParameters().stream().filter(p -> replaceParameterNames.contains(p.getName())).collect(Collectors.toList()),
+                replaceResponseDescription + "\n\n" + errorResponseDescription,
+                endpoint.getScopes(),
+                endpoint.getNotes(),
+                List.of(new SpotifyApiEndpoint.ResponseType("Void", 201, null))
+        );
+
+        category.getEndpoints().remove(endpoint.getId());
+        category.getEndpoints().put(reorderEndpoint.getId(), reorderEndpoint);
+        category.getEndpoints().put(replaceEndpoint.getId(), replaceEndpoint);
+    }
+}

--- a/spotify-web-api-core/src/main/java/de/jsone_studios/spotify/core/model/SpotifyScopes.java
+++ b/spotify-web-api-core/src/main/java/de/jsone_studios/spotify/core/model/SpotifyScopes.java
@@ -1,11 +1,15 @@
 package de.jsone_studios.spotify.core.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.SortedMap;
 
 @Getter
 @Setter
@@ -13,5 +17,15 @@ import java.util.List;
 @AllArgsConstructor
 public class SpotifyScopes {
     private String url;
-    private List<SpotifyScope> scopes;
+    private SortedMap<String, SpotifyScope> scopes;
+
+    @JsonIgnore
+    public Collection<SpotifyScope> getScopeList() {
+        return Collections.unmodifiableCollection(scopes.values());
+    }
+
+    @JsonIgnore
+    public Optional<SpotifyScope> getScope(String name) {
+        return Optional.ofNullable(scopes.get(name));
+    }
 }

--- a/spotify-web-api-generator-java/src/main/java/de/jsone_studios/spotify/generator/java/CategoryTemplate.java
+++ b/spotify-web-api-generator-java/src/main/java/de/jsone_studios/spotify/generator/java/CategoryTemplate.java
@@ -74,7 +74,7 @@ class CategoryTemplate extends AbstractTemplate<SpotifyApiCategory> {
     }
 
     private List<List<Argument>> getArguments(SpotifyApiEndpoint endpoint) {
-        fixDuplicateEndpointArguments(endpoint);
+        fixDuplicateEndpointParameters(endpoint);
 
         List<Argument> requiredArgs = new ArrayList<>();
         endpoint.getParameters().stream()
@@ -138,7 +138,14 @@ class CategoryTemplate extends AbstractTemplate<SpotifyApiCategory> {
         return "";
     }
 
-    private void fixDuplicateEndpointArguments(SpotifyApiEndpoint endpoint) {
+    /**
+     * Fixes duplicated endpoint parameters.
+     * Some endpoints allow to pass data either via query argument or via body. As the url has a length limit,
+     * passing to much data in the query string might result in an error response. Therefore this method removes
+     * the option to pass the data via query argument and makes the body parameter mandatory.
+     * @param endpoint the spotify api endpoint to fix
+     */
+    private void fixDuplicateEndpointParameters(SpotifyApiEndpoint endpoint) {
         String paramName;
         switch (endpoint.getId()) {
             case "endpoint-remove-albums-user":

--- a/spotify-web-api-generator-java/src/main/java/de/jsone_studios/spotify/generator/java/JavaGenerator.java
+++ b/spotify-web-api-generator-java/src/main/java/de/jsone_studios/spotify/generator/java/JavaGenerator.java
@@ -1,8 +1,8 @@
 package de.jsone_studios.spotify.generator.java;
 
 import com.samskivert.mustache.Mustache;
+import de.jsone_studios.spotify.core.EndpointSplitter;
 import de.jsone_studios.spotify.core.model.SpotifyApiDocumentation;
-import de.jsone_studios.spotify.core.model.SpotifyApiEndpoint;
 import de.jsone_studios.spotify.generator.java.util.JavaPackage;
 import lombok.extern.slf4j.Slf4j;
 
@@ -10,8 +10,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 public class JavaGenerator {
@@ -27,7 +25,11 @@ public class JavaGenerator {
         var objectTemplate = new ObjectTemplate().loadTemplate(this.templateCompiler);
         var apiTemplate = new CategoryTemplate().loadTemplate(this.templateCompiler);
 
-        adjustApiDocumentation(apiDocumentation);
+        try {
+            EndpointSplitter.splitEndpoints(apiDocumentation);
+        } catch (IllegalArgumentException e) {
+            throw new GeneratorException("Failed to split endpoints", e);
+        }
 
         for (var object : apiDocumentation.getObjectList()) {
             objectTemplate.generate(object, outputFolder, javaPackage);
@@ -53,51 +55,5 @@ public class JavaGenerator {
     private Reader loadTemplate(String name) {
         String fileName = String.format("/templates/%s.mustache", name);
         return new InputStreamReader(JavaGenerator.class.getResourceAsStream(fileName));
-    }
-
-    private void adjustApiDocumentation(SpotifyApiDocumentation apiDocumentation) throws GeneratorException {
-        separateUsersTopArtistsAndTracks(apiDocumentation);
-    }
-
-    private void separateUsersTopArtistsAndTracks(SpotifyApiDocumentation apiDocumentation) throws GeneratorException {
-        var category = apiDocumentation.getCategory("category-personalization")
-                .orElseThrow(() -> new GeneratorException("Can not find category-personalization"));
-
-        var topArtistsAndTracks = category.getEndpoint("endpoint-get-users-top-artists-and-tracks")
-                .orElseThrow(() -> new GeneratorException("Can not find endpoint-get-users-top-artists-and-tracks"));
-
-        var parameters = new ArrayList<>(topArtistsAndTracks.getParameters());
-        parameters.removeIf(p -> "type".equals(p.getName()));
-
-        var topArtists = new SpotifyApiEndpoint(
-                "endpoint-get-users-top-artists",
-                "Get a User's Top Artists",
-                topArtistsAndTracks.getLink(),
-                "Get the current user’s top artists based on calculated affinity.",
-                "GET",
-                "/me/top/artists",
-                parameters,
-                "On success, the HTTP status code in the response header is 200 OK and the response body contains a paging object of Artists. On error, the header status code is an error code and the response body contains an error object.",
-                topArtistsAndTracks.getScopes(),
-                topArtistsAndTracks.getNotes(),
-                List.of(new SpotifyApiEndpoint.ResponseType("PagingObject[ArtistObject]", 200, null))
-        );
-        var topTracks = new SpotifyApiEndpoint(
-                "endpoint-get-users-top-tracks",
-                "Get a User's Top Tracks",
-                topArtistsAndTracks.getLink(),
-                "Get the current user’s top tracks based on calculated affinity.",
-                "GET",
-                "/me/top/tracks",
-                parameters,
-                "On success, the HTTP status code in the response header is 200 OK and the response body contains a paging object of Tracks. On error, the header status code is an error code and the response body contains an error object.",
-                topArtistsAndTracks.getScopes(),
-                topArtistsAndTracks.getNotes(),
-                List.of(new SpotifyApiEndpoint.ResponseType("PagingObject[TrackObject]", 200, null))
-        );
-
-        category.getEndpoints().remove("endpoint-get-users-top-artists-and-tracks");
-        category.getEndpoints().put(topArtists.getId(), topArtists);
-        category.getEndpoints().put(topTracks.getId(), topTracks);
     }
 }

--- a/spotify-web-api-generator-java/src/main/java/de/jsone_studios/spotify/generator/java/ScopeTemplate.java
+++ b/spotify-web-api-generator-java/src/main/java/de/jsone_studios/spotify/generator/java/ScopeTemplate.java
@@ -27,7 +27,7 @@ public class ScopeTemplate extends AbstractTemplate<SpotifyScopes> {
     @Override
     Map<String, Object> buildContext(SpotifyScopes spotifyScopes, Map<String, Object> context) {
         context.put("url", spotifyScopes.getUrl());
-        var scopes = spotifyScopes.getScopes().stream()
+        var scopes = spotifyScopes.getScopeList().stream()
                 .map(scope -> new HashMap<>(Map.of(
                         "name", scope.getId(),
                         "enumName", CaseFormat.LOWER_HYPHEN.to(CaseFormat.UPPER_UNDERSCORE, scope.getId()),

--- a/spotify-web-api-generator-open-api/src/main/java/de/jsone_studios/spotify/generator/openapi/OpenApiGenerator.java
+++ b/spotify-web-api-generator-open-api/src/main/java/de/jsone_studios/spotify/generator/openapi/OpenApiGenerator.java
@@ -63,7 +63,7 @@ public class OpenApiGenerator {
 
     private SecurityScheme getSpotifySecurityScheme(SpotifyScopes scopes) {
         var openApiScopes = new Scopes();
-        openApiScopes.putAll(scopes.getScopes().stream().collect(Collectors
+        openApiScopes.putAll(scopes.getScopeList().stream().collect(Collectors
                 .toMap(SpotifyScope::getId, SpotifyScope::getDescription)));
 
         return new SecurityScheme()

--- a/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/apis/PersonalizationApi.java
+++ b/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/apis/PersonalizationApi.java
@@ -1,8 +1,11 @@
 package de.jsone_studios.spotify.api.apis;
 
-import de.jsone_studios.spotify.api.models.*;
+import de.jsone_studios.spotify.api.models.Artist;
+import de.jsone_studios.spotify.api.models.Paging;
+import de.jsone_studios.spotify.api.models.Track;
 import retrofit2.Call;
-import retrofit2.http.*;
+import retrofit2.http.GET;
+import retrofit2.http.QueryMap;
 
 /**
  * <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#category-personalization">Personalization API</a>
@@ -15,7 +18,7 @@ public interface PersonalizationApi {
      * <h3>Required OAuth scopes</h3>
      * <code>user-top-read</code>
      * 
-     * @return <p>On success, the HTTP status code in the response header is 200 OK and the response body contains a paging object of Artists. On error, the header status code is an error code and the response body contains an error object.</p>
+     * @return <p>On success, the HTTP status code in the response header is <code>200 OK</code> and the response body contains a <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object">paging object</a> of <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#artist-object-full">Artists</a>. On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a> and the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>.</p>
      * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks">Get a User's Top Artists</a>
      */
     @GET("/me/top/artists")
@@ -28,7 +31,7 @@ public interface PersonalizationApi {
      * <code>user-top-read</code>
      * 
      * @param queryParameters <p>A map of optional query parameters</p>
-     * @return <p>On success, the HTTP status code in the response header is 200 OK and the response body contains a paging object of Artists. On error, the header status code is an error code and the response body contains an error object.</p>
+     * @return <p>On success, the HTTP status code in the response header is <code>200 OK</code> and the response body contains a <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object">paging object</a> of <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#artist-object-full">Artists</a>. On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a> and the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>.</p>
      * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks">Get a User's Top Artists</a>
      */
     @GET("/me/top/artists")
@@ -40,7 +43,7 @@ public interface PersonalizationApi {
      * <h3>Required OAuth scopes</h3>
      * <code>user-top-read</code>
      * 
-     * @return <p>On success, the HTTP status code in the response header is 200 OK and the response body contains a paging object of Tracks. On error, the header status code is an error code and the response body contains an error object.</p>
+     * @return <p>On success, the HTTP status code in the response header is <code>200 OK</code> and the response body contains a <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object">paging object</a> of <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full">Tracks</a>. On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a> and the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>.</p>
      * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks">Get a User's Top Tracks</a>
      */
     @GET("/me/top/tracks")
@@ -53,7 +56,7 @@ public interface PersonalizationApi {
      * <code>user-top-read</code>
      * 
      * @param queryParameters <p>A map of optional query parameters</p>
-     * @return <p>On success, the HTTP status code in the response header is 200 OK and the response body contains a paging object of Tracks. On error, the header status code is an error code and the response body contains an error object.</p>
+     * @return <p>On success, the HTTP status code in the response header is <code>200 OK</code> and the response body contains a <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#paging-object">paging object</a> of <a href="https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-full">Tracks</a>. On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a> and the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>.</p>
      * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-top-artists-and-tracks">Get a User's Top Tracks</a>
      */
     @GET("/me/top/tracks")

--- a/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/apis/PlaylistsApi.java
+++ b/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/apis/PlaylistsApi.java
@@ -208,60 +208,45 @@ public interface PlaylistsApi {
     Call<SnapshotId> removeTracksPlaylist(@Path("playlist_id") String playlist_id, @Body RemoveTracksPlaylistRequest requestBody);
 
     /**
-     * <h3>Reorder or Replace a Playlist's Items</h3>
-     * <p>Either reorder or replace items in a playlist depending on the request's parameters. To reorder items, include <code>range_start</code>, <code>insert_before</code>, <code>range_length</code> and <code>snapshot_id</code> in the request's body. To replace items, include <code>uris</code> as either a query parameter or in the request's body. Replacing items in a playlist will overwrite its existing items. This operation can be used for replacing or clearing items in a playlist.</p> <p><strong>Note</strong>: Replace and reorder are mutually exclusive operations which share the same endpoint, but have different parameters. These operations can't be applied together in a single request.</p>
+     * <h3>Reorder items in a playlist</h3>
+     * <p>Reorder an item or a group of items in a playlist.</p>
      * <h3>Required OAuth scopes</h3>
      * <code>playlist-modify-public, playlist-modify-private</code>
      * 
      * @param playlist_id <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the playlist.</p>
-     * @return <p>On a successful <strong>reorder</strong> operation, the response body contains a <code>snapshot_id</code> in JSON format and the HTTP status code in the response header is <code>200</code> OK. The <code>snapshot_id</code> can be used to identify your playlist version in future requests.</p> <p>On a successful <strong>replace</strong> operation, the HTTP status code in the response header is <code>201</code> Created.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
-     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Reorder or Replace a Playlist's Items</a>
+     * @return <p>On a successful <strong>reorder</strong> operation, the response body contains a <code>snapshot_id</code> in JSON format and the HTTP status code in the response header is <code>200</code> OK. The <code>snapshot_id</code> can be used to identify your playlist version in future requests.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
+     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Reorder items in a playlist</a>
      */
     @PUT("/playlists/{playlist_id}/tracks")
-    Call<SnapshotId> reorderOrReplacePlaylistsTracks(@Path("playlist_id") String playlist_id);
+    Call<SnapshotId> reorderPlaylistsTracks(@Path("playlist_id") String playlist_id);
 
     /**
-     * <h3>Reorder or Replace a Playlist's Items</h3>
-     * <p>Either reorder or replace items in a playlist depending on the request's parameters. To reorder items, include <code>range_start</code>, <code>insert_before</code>, <code>range_length</code> and <code>snapshot_id</code> in the request's body. To replace items, include <code>uris</code> as either a query parameter or in the request's body. Replacing items in a playlist will overwrite its existing items. This operation can be used for replacing or clearing items in a playlist.</p> <p><strong>Note</strong>: Replace and reorder are mutually exclusive operations which share the same endpoint, but have different parameters. These operations can't be applied together in a single request.</p>
+     * <h3>Reorder items in a playlist</h3>
+     * <p>Reorder an item or a group of items in a playlist.</p>
      * <h3>Required OAuth scopes</h3>
      * <code>playlist-modify-public, playlist-modify-private</code>
      * 
      * @param playlist_id <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the playlist.</p>
      * @param requestBody <p>The request body</p>
-     * @return <p>On a successful <strong>reorder</strong> operation, the response body contains a <code>snapshot_id</code> in JSON format and the HTTP status code in the response header is <code>200</code> OK. The <code>snapshot_id</code> can be used to identify your playlist version in future requests.</p> <p>On a successful <strong>replace</strong> operation, the HTTP status code in the response header is <code>201</code> Created.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
-     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Reorder or Replace a Playlist's Items</a>
+     * @return <p>On a successful <strong>reorder</strong> operation, the response body contains a <code>snapshot_id</code> in JSON format and the HTTP status code in the response header is <code>200</code> OK. The <code>snapshot_id</code> can be used to identify your playlist version in future requests.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
+     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Reorder items in a playlist</a>
      */
     @PUT("/playlists/{playlist_id}/tracks")
-    Call<SnapshotId> reorderOrReplacePlaylistsTracks(@Path("playlist_id") String playlist_id, @Body ReorderOrReplacePlaylistsTracksRequest requestBody);
+    Call<SnapshotId> reorderPlaylistsTracks(@Path("playlist_id") String playlist_id, @Body ReorderPlaylistsTracksRequest requestBody);
 
     /**
-     * <h3>Reorder or Replace a Playlist's Items</h3>
-     * <p>Either reorder or replace items in a playlist depending on the request's parameters. To reorder items, include <code>range_start</code>, <code>insert_before</code>, <code>range_length</code> and <code>snapshot_id</code> in the request's body. To replace items, include <code>uris</code> as either a query parameter or in the request's body. Replacing items in a playlist will overwrite its existing items. This operation can be used for replacing or clearing items in a playlist.</p> <p><strong>Note</strong>: Replace and reorder are mutually exclusive operations which share the same endpoint, but have different parameters. These operations can't be applied together in a single request.</p>
+     * <h3>Replace items in a playlist</h3>
+     * <p>Replace all the items in a playlist, overwriting its existing items. This powerful request can be useful for replacing items, re-ordering existing items, or clearing the playlist.</p>
      * <h3>Required OAuth scopes</h3>
      * <code>playlist-modify-public, playlist-modify-private</code>
      * 
      * @param playlist_id <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the playlist.</p>
-     * @param uris <p>A comma-separated list of <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URIs</a> to set, can be track or episode URIs. For example: <code>uris=spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M,spotify:episode:512ojhOuo1ktJprKbVcKyQ</code><br> A maximum of 100 items can be set in one request.</p>
-     * @return <p>On a successful <strong>reorder</strong> operation, the response body contains a <code>snapshot_id</code> in JSON format and the HTTP status code in the response header is <code>200</code> OK. The <code>snapshot_id</code> can be used to identify your playlist version in future requests.</p> <p>On a successful <strong>replace</strong> operation, the HTTP status code in the response header is <code>201</code> Created.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
-     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Reorder or Replace a Playlist's Items</a>
+     * @param requestBody <p>the request body</p>
+     * @return <p>On a successful <strong>replace</strong> operation, the HTTP status code in the response header is <code>201</code> Created.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
+     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Replace items in a playlist</a>
      */
     @PUT("/playlists/{playlist_id}/tracks")
-    Call<SnapshotId> reorderOrReplacePlaylistsTracks(@Path("playlist_id") String playlist_id, @Query("uris") String uris);
-
-    /**
-     * <h3>Reorder or Replace a Playlist's Items</h3>
-     * <p>Either reorder or replace items in a playlist depending on the request's parameters. To reorder items, include <code>range_start</code>, <code>insert_before</code>, <code>range_length</code> and <code>snapshot_id</code> in the request's body. To replace items, include <code>uris</code> as either a query parameter or in the request's body. Replacing items in a playlist will overwrite its existing items. This operation can be used for replacing or clearing items in a playlist.</p> <p><strong>Note</strong>: Replace and reorder are mutually exclusive operations which share the same endpoint, but have different parameters. These operations can't be applied together in a single request.</p>
-     * <h3>Required OAuth scopes</h3>
-     * <code>playlist-modify-public, playlist-modify-private</code>
-     * 
-     * @param playlist_id <p>The <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify ID</a> for the playlist.</p>
-     * @param uris <p>A comma-separated list of <a href="https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids">Spotify URIs</a> to set, can be track or episode URIs. For example: <code>uris=spotify:track:4iV5W9uYEdYUVa79Axb7Rh,spotify:track:1301WleyT98MSxVHPZCA6M,spotify:episode:512ojhOuo1ktJprKbVcKyQ</code><br> A maximum of 100 items can be set in one request.</p>
-     * @param requestBody <p>The request body</p>
-     * @return <p>On a successful <strong>reorder</strong> operation, the response body contains a <code>snapshot_id</code> in JSON format and the HTTP status code in the response header is <code>200</code> OK. The <code>snapshot_id</code> can be used to identify your playlist version in future requests.</p> <p>On a successful <strong>replace</strong> operation, the HTTP status code in the response header is <code>201</code> Created.</p> <p>On error, the header status code is an <a href="https://developer.spotify.com/documentation/web-api/#response-status-codes">error code</a>, the response body contains an <a href="https://developer.spotify.com/documentation/web-api/#response-schema">error object</a>, and the existing playlist is unmodified. Trying to set an item when you do not have the user's authorization returns error <code>403</code> Forbidden.</p>
-     * @see <a href="https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-reorder-or-replace-playlists-tracks">Reorder or Replace a Playlist's Items</a>
-     */
-    @PUT("/playlists/{playlist_id}/tracks")
-    Call<SnapshotId> reorderOrReplacePlaylistsTracks(@Path("playlist_id") String playlist_id, @Query("uris") String uris, @Body ReorderOrReplacePlaylistsTracksRequest requestBody);
+    Call<Void> replacePlaylistsTracks(@Path("playlist_id") String playlist_id, @Body ReplacePlaylistsTracksRequest requestBody);
 
     /**
      * <h3>Upload a Custom Playlist Cover Image</h3>

--- a/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/models/ReorderPlaylistsTracksRequest.java
+++ b/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/models/ReorderPlaylistsTracksRequest.java
@@ -1,12 +1,13 @@
 package de.jsone_studios.spotify.api.models;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
 @NoArgsConstructor
-public class ReorderOrReplacePlaylistsTracksRequest {
-    private java.util.List<String> uris;
+public class ReorderPlaylistsTracksRequest {
     /**
      * <p>The position of the first item to be reordered.</p>
      */

--- a/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/models/ReplacePlaylistsTracksRequest.java
+++ b/spotify-web-api-java/src/main/generated/de/jsone_studios/spotify/api/models/ReplacePlaylistsTracksRequest.java
@@ -1,0 +1,12 @@
+package de.jsone_studios.spotify.api.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReplacePlaylistsTracksRequest {
+    private java.util.List<String> uris;
+}

--- a/spotify-web-api-parser/api-documentation.yaml
+++ b/spotify-web-api-parser/api-documentation.yaml
@@ -5553,290 +5553,309 @@ categories:
 scopes:
   url: https://developer.spotify.com/documentation/general/guides/scopes
   scopes:
-  - id: app-remote-control
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#app-remote-control
-    description: Remote control playback of Spotify. This scope is currently available
-      to Spotify iOS and Android SDKs.
-    userDescription: Communicate with the Spotify app on your device.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/ios/
-      api: ios
-    - url: https://developer.spotify.com/documentation/android/
-      api: android
-  - id: playlist-modify-private
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-modify-private
-    description: Write access to a user's private playlists.
-    userDescription: Manage your private playlists.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/follow-playlist/
-      api: web-api
-      endpoint: endpoint-follow-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-playlist/
-      api: web-api
-      endpoint: endpoint-unfollow-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/add-tracks-to-playlist/
-      api: web-api
-      endpoint: endpoint-add-tracks-to-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/change-playlist-details/
-      api: web-api
-      endpoint: endpoint-change-playlist-details
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/create-playlist/
-      api: web-api
-      endpoint: endpoint-create-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/remove-tracks-playlist/
-      api: web-api
-      endpoint: endpoint-remove-tracks-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/reorder-playlists-tracks/
-      api: web-api
-      endpoint: endpoint-reorder-or-replace-playlists-tracks
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/replace-playlists-tracks/
-      api: web-api
-      endpoint: endpoint-reorder-or-replace-playlists-tracks
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/
-      api: web-api
-      endpoint: endpoint-upload-custom-playlist-cover
-  - id: playlist-modify-public
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-modify-public
-    description: Write access to a user's public playlists.
-    userDescription: Manage your public playlists.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/follow-playlist/
-      api: web-api
-      endpoint: endpoint-follow-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-playlist/
-      api: web-api
-      endpoint: endpoint-unfollow-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/add-tracks-to-playlist/
-      api: web-api
-      endpoint: endpoint-add-tracks-to-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/change-playlist-details/
-      api: web-api
-      endpoint: endpoint-change-playlist-details
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/create-playlist/
-      api: web-api
-      endpoint: endpoint-create-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/remove-tracks-playlist/
-      api: web-api
-      endpoint: endpoint-remove-tracks-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/reorder-playlists-tracks/
-      api: web-api
-      endpoint: endpoint-reorder-or-replace-playlists-tracks
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/replace-playlists-tracks/
-      api: web-api
-      endpoint: endpoint-reorder-or-replace-playlists-tracks
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/
-      api: web-api
-      endpoint: endpoint-upload-custom-playlist-cover
-  - id: playlist-read-collaborative
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-read-collaborative
-    description: Include collaborative playlists when requesting a user's playlists.
-    userDescription: Access your collaborative playlists.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-a-list-of-current-users-playlists/
-      api: web-api
-      endpoint: endpoint-get-a-list-of-current-users-playlists
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-list-users-playlists/
-      api: web-api
-      endpoint: endpoint-get-list-users-playlists
-  - id: playlist-read-private
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-read-private
-    description: Read access to user's private playlists.
-    userDescription: Access your private playlists.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/check-user-following-playlist/
-      api: web-api
-      endpoint: endpoint-check-if-user-follows-playlist
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-a-list-of-current-users-playlists/
-      api: web-api
-      endpoint: endpoint-get-a-list-of-current-users-playlists
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-list-users-playlists/
-      api: web-api
-      endpoint: endpoint-get-list-users-playlists
-  - id: streaming
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#streaming
-    description: Control playback of a Spotify track. This scope is currently available
-      to the Web Playback SDK. The user must have a Spotify Premium account.
-    userDescription: Play content and control playback on your other devices.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-playback-sdk/
-      api: web-playback-sdk
-  - id: ugc-image-upload
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#ugc-image-upload
-    description: Write access to user-provided images.
-    userDescription: Upload images to Spotify on your behalf.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/
-      api: web-api
-      endpoint: endpoint-upload-custom-playlist-cover
-  - id: user-follow-modify
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-follow-modify
-    description: Write/delete access to the list of artists and other users that the
-      user follows.
-    userDescription: Manage who you are following.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/follow-artists-users/
-      api: web-api
-      endpoint: endpoint-follow-artists-users
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-artists-users/
-      api: web-api
-      endpoint: endpoint-unfollow-artists-users
-  - id: user-follow-read
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-follow-read
-    description: Read access to the list of artists and other users that the user
-      follows.
-    userDescription: Access your followers and who you are following.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/check-current-user-follows/
-      api: web-api
-      endpoint: endpoint-check-current-user-follows
-    - url: https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/
-      api: web-api
-      endpoint: endpoint-get-followed
-  - id: user-library-modify
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-library-modify
-    description: Write/delete access to a user's "Your Music" library.
-    userDescription: Manage your saved content.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/remove-albums-user/
-      api: web-api
-      endpoint: endpoint-remove-albums-user
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/remove-tracks-user/
-      api: web-api
-      endpoint: endpoint-remove-tracks-user
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/save-albums-user/
-      api: web-api
-      endpoint: endpoint-save-albums-user
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/save-tracks-user/
-      api: web-api
-      endpoint: endpoint-save-tracks-user
-  - id: user-library-read
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-library-read
-    description: Read access to a user's "Your Music" library.
-    userDescription: Access your saved content.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-albums/
-      api: web-api
-      endpoint: endpoint-check-users-saved-albums
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-tracks/
-      api: web-api
-      endpoint: endpoint-check-users-saved-tracks
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-albums/
-      api: web-api
-      endpoint: endpoint-get-users-saved-albums
-    - url: https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-tracks/
-      api: web-api
-      endpoint: endpoint-get-users-saved-tracks
-  - id: user-modify-playback-state
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-modify-playback-state
-    description: Write access to a user’s playback state
-    userDescription: Control playback on your Spotify clients and Spotify Connect
-      devices.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/pause-a-users-playback/
-      api: web-api
-      endpoint: endpoint-pause-a-users-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/seek-to-position-in-currently-playing-track/
-      api: web-api
-      endpoint: endpoint-seek-to-position-in-currently-playing-track
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/set-repeat-mode-on-users-playback/
-      api: web-api
-      endpoint: endpoint-set-repeat-mode-on-users-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/set-volume-for-users-playback/
-      api: web-api
-      endpoint: endpoint-set-volume-for-users-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/skip-users-playback-to-next-track/
-      api: web-api
-      endpoint: endpoint-skip-users-playback-to-next-track
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/skip-users-playback-to-previous-track/
-      api: web-api
-      endpoint: endpoint-skip-users-playback-to-previous-track
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/
-      api: web-api
-      endpoint: endpoint-start-a-users-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/toggle-shuffle-for-users-playback/
-      api: web-api
-      endpoint: endpoint-toggle-shuffle-for-users-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/transfer-a-users-playback/
-      api: web-api
-      endpoint: endpoint-transfer-a-users-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/seek-to-position-in-currently-playing-track/
-      api: web-api
-      endpoint: endpoint-seek-to-position-in-currently-playing-track
-  - id: user-read-currently-playing
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-currently-playing
-    description: Read access to a user’s currently playing content.
-    userDescription: Read your currently playing content.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/
-      api: web-api
-      endpoint: endpoint-get-the-users-currently-playing-track
-  - id: user-read-email
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-email
-    description: Read access to user’s email address.
-    userDescription: Get your real email address.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/
-      api: web-api
-      endpoint: endpoint-get-current-users-profile
-  - id: user-read-playback-position
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-playback-position
-    description: Read access to a user’s playback position in a content.
-    userDescription: Read your position in content you have played.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/episodes/get-an-episode/
-      api: web-api
-      endpoint: endpoint-get-an-episode
-    - url: https://developer.spotify.com/documentation/web-api/reference/episodes/get-several-episodes/
-      api: web-api
-      endpoint: endpoint-get-multiple-episodes
-    - url: https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/
-      api: web-api
-      endpoint: endpoint-get-a-show
-    - url: https://developer.spotify.com/documentation/web-api/reference/shows/get-several-shows/
-      api: web-api
-      endpoint: endpoint-get-multiple-shows
-    - url: https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/
-      api: web-api
-      endpoint: endpoint-get-a-shows-episodes
-  - id: user-read-playback-state
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-playback-state
-    description: Read access to a user’s player state.
-    userDescription: Read your currently playing content and Spotify Connect devices
-      information.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/
-      api: web-api
-      endpoint: endpoint-get-a-users-available-devices
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/
-      api: web-api
-      endpoint: endpoint-get-information-about-the-users-current-playback
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/
-      api: web-api
-      endpoint: endpoint-get-the-users-currently-playing-track
-  - id: user-read-private
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-private
-    description: Read access to user’s subscription details (type of user account).
-    userDescription: Access your subscription details.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/search/search/
-      api: web-api
-      endpoint: endpoint-search
-    - url: https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/
-      api: web-api
-      endpoint: endpoint-get-current-users-profile
-  - id: user-read-recently-played
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-recently-played
-    description: Read access to a user’s recently played tracks.
-    userDescription: Access your recently played items.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/player/get-recently-played/
-      api: web-api
-      endpoint: endpoint-get-recently-played
-  - id: user-top-read
-    link: https://developer.spotify.com/documentation/general/guides/scopes/#user-top-read
-    description: Read access to a user's top artists and tracks.
-    userDescription: Read your top artists and content.
-    endpoints:
-    - url: https://developer.spotify.com/documentation/web-api/reference/personalization/get-users-top-artists-and-tracks/
-      api: web-api
-      endpoint: endpoint-get-users-top-artists-and-tracks
+    app-remote-control:
+      id: app-remote-control
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#app-remote-control
+      description: Remote control playback of Spotify. This scope is currently available
+        to Spotify iOS and Android SDKs.
+      userDescription: Communicate with the Spotify app on your device.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/ios/
+        api: ios
+      - url: https://developer.spotify.com/documentation/android/
+        api: android
+    playlist-modify-private:
+      id: playlist-modify-private
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-modify-private
+      description: Write access to a user's private playlists.
+      userDescription: Manage your private playlists.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/follow-playlist/
+        api: web-api
+        endpoint: endpoint-follow-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-playlist/
+        api: web-api
+        endpoint: endpoint-unfollow-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/add-tracks-to-playlist/
+        api: web-api
+        endpoint: endpoint-add-tracks-to-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/change-playlist-details/
+        api: web-api
+        endpoint: endpoint-change-playlist-details
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/create-playlist/
+        api: web-api
+        endpoint: endpoint-create-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/remove-tracks-playlist/
+        api: web-api
+        endpoint: endpoint-remove-tracks-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/reorder-playlists-tracks/
+        api: web-api
+        endpoint: endpoint-reorder-or-replace-playlists-tracks
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/replace-playlists-tracks/
+        api: web-api
+        endpoint: endpoint-reorder-or-replace-playlists-tracks
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/
+        api: web-api
+        endpoint: endpoint-upload-custom-playlist-cover
+    playlist-modify-public:
+      id: playlist-modify-public
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-modify-public
+      description: Write access to a user's public playlists.
+      userDescription: Manage your public playlists.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/follow-playlist/
+        api: web-api
+        endpoint: endpoint-follow-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-playlist/
+        api: web-api
+        endpoint: endpoint-unfollow-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/add-tracks-to-playlist/
+        api: web-api
+        endpoint: endpoint-add-tracks-to-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/change-playlist-details/
+        api: web-api
+        endpoint: endpoint-change-playlist-details
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/create-playlist/
+        api: web-api
+        endpoint: endpoint-create-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/remove-tracks-playlist/
+        api: web-api
+        endpoint: endpoint-remove-tracks-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/reorder-playlists-tracks/
+        api: web-api
+        endpoint: endpoint-reorder-or-replace-playlists-tracks
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/replace-playlists-tracks/
+        api: web-api
+        endpoint: endpoint-reorder-or-replace-playlists-tracks
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/
+        api: web-api
+        endpoint: endpoint-upload-custom-playlist-cover
+    playlist-read-collaborative:
+      id: playlist-read-collaborative
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-read-collaborative
+      description: Include collaborative playlists when requesting a user's playlists.
+      userDescription: Access your collaborative playlists.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-a-list-of-current-users-playlists/
+        api: web-api
+        endpoint: endpoint-get-a-list-of-current-users-playlists
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-list-users-playlists/
+        api: web-api
+        endpoint: endpoint-get-list-users-playlists
+    playlist-read-private:
+      id: playlist-read-private
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#playlist-read-private
+      description: Read access to user's private playlists.
+      userDescription: Access your private playlists.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/check-user-following-playlist/
+        api: web-api
+        endpoint: endpoint-check-if-user-follows-playlist
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-a-list-of-current-users-playlists/
+        api: web-api
+        endpoint: endpoint-get-a-list-of-current-users-playlists
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/get-list-users-playlists/
+        api: web-api
+        endpoint: endpoint-get-list-users-playlists
+    streaming:
+      id: streaming
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#streaming
+      description: Control playback of a Spotify track. This scope is currently available
+        to the Web Playback SDK. The user must have a Spotify Premium account.
+      userDescription: Play content and control playback on your other devices.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-playback-sdk/
+        api: web-playback-sdk
+    ugc-image-upload:
+      id: ugc-image-upload
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#ugc-image-upload
+      description: Write access to user-provided images.
+      userDescription: Upload images to Spotify on your behalf.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/playlists/upload-custom-playlist-cover/
+        api: web-api
+        endpoint: endpoint-upload-custom-playlist-cover
+    user-follow-modify:
+      id: user-follow-modify
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-follow-modify
+      description: Write/delete access to the list of artists and other users that
+        the user follows.
+      userDescription: Manage who you are following.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/follow-artists-users/
+        api: web-api
+        endpoint: endpoint-follow-artists-users
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/unfollow-artists-users/
+        api: web-api
+        endpoint: endpoint-unfollow-artists-users
+    user-follow-read:
+      id: user-follow-read
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-follow-read
+      description: Read access to the list of artists and other users that the user
+        follows.
+      userDescription: Access your followers and who you are following.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/check-current-user-follows/
+        api: web-api
+        endpoint: endpoint-check-current-user-follows
+      - url: https://developer.spotify.com/documentation/web-api/reference/follow/get-followed/
+        api: web-api
+        endpoint: endpoint-get-followed
+    user-library-modify:
+      id: user-library-modify
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-library-modify
+      description: Write/delete access to a user's "Your Music" library.
+      userDescription: Manage your saved content.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/remove-albums-user/
+        api: web-api
+        endpoint: endpoint-remove-albums-user
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/remove-tracks-user/
+        api: web-api
+        endpoint: endpoint-remove-tracks-user
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/save-albums-user/
+        api: web-api
+        endpoint: endpoint-save-albums-user
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/save-tracks-user/
+        api: web-api
+        endpoint: endpoint-save-tracks-user
+    user-library-read:
+      id: user-library-read
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-library-read
+      description: Read access to a user's "Your Music" library.
+      userDescription: Access your saved content.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-albums/
+        api: web-api
+        endpoint: endpoint-check-users-saved-albums
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-tracks/
+        api: web-api
+        endpoint: endpoint-check-users-saved-tracks
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-albums/
+        api: web-api
+        endpoint: endpoint-get-users-saved-albums
+      - url: https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-tracks/
+        api: web-api
+        endpoint: endpoint-get-users-saved-tracks
+    user-modify-playback-state:
+      id: user-modify-playback-state
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-modify-playback-state
+      description: Write access to a user’s playback state
+      userDescription: Control playback on your Spotify clients and Spotify Connect
+        devices.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/pause-a-users-playback/
+        api: web-api
+        endpoint: endpoint-pause-a-users-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/seek-to-position-in-currently-playing-track/
+        api: web-api
+        endpoint: endpoint-seek-to-position-in-currently-playing-track
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/set-repeat-mode-on-users-playback/
+        api: web-api
+        endpoint: endpoint-set-repeat-mode-on-users-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/set-volume-for-users-playback/
+        api: web-api
+        endpoint: endpoint-set-volume-for-users-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/skip-users-playback-to-next-track/
+        api: web-api
+        endpoint: endpoint-skip-users-playback-to-next-track
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/skip-users-playback-to-previous-track/
+        api: web-api
+        endpoint: endpoint-skip-users-playback-to-previous-track
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/
+        api: web-api
+        endpoint: endpoint-start-a-users-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/toggle-shuffle-for-users-playback/
+        api: web-api
+        endpoint: endpoint-toggle-shuffle-for-users-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/transfer-a-users-playback/
+        api: web-api
+        endpoint: endpoint-transfer-a-users-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/seek-to-position-in-currently-playing-track/
+        api: web-api
+        endpoint: endpoint-seek-to-position-in-currently-playing-track
+    user-read-currently-playing:
+      id: user-read-currently-playing
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-currently-playing
+      description: Read access to a user’s currently playing content.
+      userDescription: Read your currently playing content.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/
+        api: web-api
+        endpoint: endpoint-get-the-users-currently-playing-track
+    user-read-email:
+      id: user-read-email
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-email
+      description: Read access to user’s email address.
+      userDescription: Get your real email address.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/
+        api: web-api
+        endpoint: endpoint-get-current-users-profile
+    user-read-playback-position:
+      id: user-read-playback-position
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-playback-position
+      description: Read access to a user’s playback position in a content.
+      userDescription: Read your position in content you have played.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/episodes/get-an-episode/
+        api: web-api
+        endpoint: endpoint-get-an-episode
+      - url: https://developer.spotify.com/documentation/web-api/reference/episodes/get-several-episodes/
+        api: web-api
+        endpoint: endpoint-get-multiple-episodes
+      - url: https://developer.spotify.com/documentation/web-api/reference/shows/get-a-show/
+        api: web-api
+        endpoint: endpoint-get-a-show
+      - url: https://developer.spotify.com/documentation/web-api/reference/shows/get-several-shows/
+        api: web-api
+        endpoint: endpoint-get-multiple-shows
+      - url: https://developer.spotify.com/documentation/web-api/reference/shows/get-shows-episodes/
+        api: web-api
+        endpoint: endpoint-get-a-shows-episodes
+    user-read-playback-state:
+      id: user-read-playback-state
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-playback-state
+      description: Read access to a user’s player state.
+      userDescription: Read your currently playing content and Spotify Connect devices
+        information.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/get-a-users-available-devices/
+        api: web-api
+        endpoint: endpoint-get-a-users-available-devices
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/get-information-about-the-users-current-playback/
+        api: web-api
+        endpoint: endpoint-get-information-about-the-users-current-playback
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/
+        api: web-api
+        endpoint: endpoint-get-the-users-currently-playing-track
+    user-read-private:
+      id: user-read-private
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-private
+      description: Read access to user’s subscription details (type of user account).
+      userDescription: Access your subscription details.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/search/search/
+        api: web-api
+        endpoint: endpoint-search
+      - url: https://developer.spotify.com/documentation/web-api/reference/users-profile/get-current-users-profile/
+        api: web-api
+        endpoint: endpoint-get-current-users-profile
+    user-read-recently-played:
+      id: user-read-recently-played
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-read-recently-played
+      description: Read access to a user’s recently played tracks.
+      userDescription: Access your recently played items.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/player/get-recently-played/
+        api: web-api
+        endpoint: endpoint-get-recently-played
+    user-top-read:
+      id: user-top-read
+      link: https://developer.spotify.com/documentation/general/guides/scopes/#user-top-read
+      description: Read access to a user's top artists and tracks.
+      userDescription: Read your top artists and content.
+      endpoints:
+      - url: https://developer.spotify.com/documentation/web-api/reference/personalization/get-users-top-artists-and-tracks/
+        api: web-api
+        endpoint: endpoint-get-users-top-artists-and-tracks


### PR DESCRIPTION
- Core: Add EndpointSplitter class, which can split endpoint-reorder-or-replace-playlists-tracks and endpoint-get-users-top-artists-and-tracks
- Core: Change scopes from list to map

Fix #14